### PR TITLE
Workaround for accessing the webhook's query in the body of the Webhook

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
   "author": "elastic.io GmbH",
   "license": "BSD-2-Clause",
   "dependencies": {
-    "debug": "^2.2.0",
-    "elasticio-sailor-nodejs": "2.1.0",
+    "debug": "^3.1.0",
+    "elasticio-sailor-nodejs": "2.2.1",
     "elasticio-node": "0.0.8",
-    "node-uuid": "1.3.3",
-    "request": "2.60.x",
-    "q": "^1.4.1"
+    "node-uuid": "1.4.8",
+    "request": "2.83.x",
+    "q": "^1.5.1"
   },
   "devDependencies": {
-    "nock": "8.0.0",
-    "jasmine-node": "~1.7.0"
+    "nock": "9.2.3",
+    "jasmine-node": "~1.14.5"
   }
 }

--- a/receive.js
+++ b/receive.js
@@ -6,6 +6,10 @@ exports.process = function (msg, conf) {
     console.log("Received new message with id", msgId);
     console.log(msg);
 
+    if (msg.query && msg.body) {
+        msg.body._query = msg.query;
+    }
+
     var self = this;
 
     Q()

--- a/spec/webhook.spec.js
+++ b/spec/webhook.spec.js
@@ -288,7 +288,37 @@ describe("Webhook", function () {
         }, 'Timed Out', 1000);
 
         runs(function () {
+            expect(self.emit.calls[0].args[1]).toBeDefined();
+            expect(self.emit.calls[0].args[1].body).toBeDefined();
+            expect(self.emit.calls[0].args[1].body._query).toBeUndefined();
+            expect(self.emit.calls[0].args).toEqual(['data', msg]);
+            expect(self.emit.calls[1].args).toEqual(['end']);
+        });
+    });
 
+    it('Inbound with query', function () {
+        var msg = {
+            body: {
+                foo: "bar"
+            },
+            query : {
+                baz: 'boo'
+            }
+        };
+
+
+        runs(function () {
+            receive.process.call(self, msg, {});
+        });
+
+        waitsFor(function () {
+            return self.emit.calls.length === 2;
+        }, 'Timed Out', 1000);
+
+        runs(function () {
+            expect(self.emit.calls[0].args[1]).toBeDefined();
+            expect(self.emit.calls[0].args[1].body).toBeDefined();
+            expect(self.emit.calls[0].args[1].body._query).toEqual({baz: 'boo'});
             expect(self.emit.calls[0].args).toEqual(['data', msg]);
             expect(self.emit.calls[1].args).toEqual(['end']);
         });


### PR DESCRIPTION
Related to https://github.com/elasticio/webhooks/issues/70